### PR TITLE
Eliminate round trip time when calling Redis in Sidekiq middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Eliminate round trip time when calling Redis in Sidekiq middleware ([#3](https://github.com/hibachrach/sidekiq-disposal/pull/3))
+
 ## [0.1.0] - 2024-12-13
 
 - A new thing! The initial release of `sidekiq-disposal`. 🎉


### PR DESCRIPTION
Now instead of waiting for an intermediate response, we're executing them immediately and cutting out the round trip time (RTT).

See https://redis.io/docs/latest/develop/use/pipelining/ for details.