### PR TITLE
Replace all usages of "drop" with "discard" to align with Sidekiq terminology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking**: Replace all usages of "drop" with "discard" to align with Sidekiq terminology ([#4](https://github.com/hibachrach/sidekiq-disposal/pull/4)).
+  - To upgrade:
+    1. Replace all usages of `:drop` with `:discard`
+    1. Replace all usages of `Sidekiq::Disposal::Client::REDIS_DROP_TARGET_SET` with `Sidekiq::Disposal::Client::REDIS_DISCARD_TARGET_SET`
+    1. Replace all usages of `Sidekiq::Disposal::JobDropped` with `Sidekiq::Disposal::JobDiscarded`
+    1. Replace all usages of `Sidekiq::Disposal::Client#drop_target?` with `Sidekiq::Disposal::Client#discard_target?`
+    1. In Redis, execute `COPY sidekiq-disposal:drop_targets sidekiq-disposal:discard_targets`
 - Eliminate round trip time when calling Redis in Sidekiq middleware ([#3](https://github.com/hibachrach/sidekiq-disposal/pull/3))
 
 ## [0.1.0] - 2024-12-13

--- a/lib/sidekiq/disposal.rb
+++ b/lib/sidekiq/disposal.rb
@@ -7,11 +7,11 @@ require_relative "disposal/server_middleware"
 module Sidekiq
   # Namespace for everything related to job disposal: the process of putting
   # jobs' markers (i.e. identifying features) on a list so they can be "killed"
-  # (sent immediately to dead set/morgue) or "dropped" (completely discarded
+  # (sent immediately to dead set/morgue) or "discarded" (completely discarded
   # from Sidekiq) when picked up from the queue.
   module Disposal
     Error = Class.new(StandardError)
     JobKilled = Class.new(Error)
-    JobDropped = Class.new(Error)
+    JobDiscarded = Class.new(Error)
   end
 end

--- a/lib/sidekiq/disposal/server_middleware.rb
+++ b/lib/sidekiq/disposal/server_middleware.rb
@@ -19,8 +19,8 @@ module Sidekiq
           case disposal_method
           when :kill
             raise JobKilled
-          when :drop
-            raise JobDropped
+          when :discard
+            raise JobDiscarded
           end
         else
           yield

--- a/sidekiq-disposal.gemspec
+++ b/sidekiq-disposal.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary = "A mechanism to dispose of (cancel) queued jobs by Job ID, Batch ID, or Job Class."
   spec.description = <<~DESC
     A mechanism to mark Sidekiq Jobs to be disposed of by Job ID, Batch ID, or Job Class.
-    Disposal here means to either `:kill` the Job (send to the Dead queue) or `:drop` it (throw it away), at the time the job is picked up and processed by Sidekiq.
+    Disposal here means to either `:kill` the Job (send to the Dead queue) or `:discard` it (throw it away), at the time the job is picked up and processed by Sidekiq.
   DESC
   spec.homepage = "https://github.com/hibachrach/sidekiq-disposal"
   spec.license = "MIT"

--- a/spec/sidekiq/disposal/client_spec.rb
+++ b/spec/sidekiq/disposal/client_spec.rb
@@ -32,43 +32,43 @@ RSpec.describe Sidekiq::Disposal::Client, :with_test_redis do
     it "can mark job to be killed by jid" do
       client.mark(:kill, :jid, bad_job["jid"])
       expect(client.kill_target?(bad_job)).to be_truthy
-      expect(client.drop_target?(bad_job)).to be_falsey
+      expect(client.discard_target?(bad_job)).to be_falsey
       expect(client.kill_target?(good_job)).to be_falsey
     end
 
     it "can mark job to be killed by bid" do
       client.mark(:kill, :bid, bad_job["bid"])
       expect(client.kill_target?(bad_job)).to be_truthy
-      expect(client.drop_target?(bad_job)).to be_falsey
+      expect(client.discard_target?(bad_job)).to be_falsey
       expect(client.kill_target?(good_job)).to be_falsey
     end
 
     it "can mark job to be killed by class" do
       client.mark(:kill, :class, bad_job["class"])
       expect(client.kill_target?(bad_job)).to be_truthy
-      expect(client.drop_target?(bad_job)).to be_falsey
+      expect(client.discard_target?(bad_job)).to be_falsey
       expect(client.kill_target?(good_job)).to be_falsey
     end
 
-    it "can mark job to be dropped by jid" do
-      client.mark(:drop, :jid, bad_job["jid"])
-      expect(client.drop_target?(bad_job)).to be_truthy
+    it "can mark job to be discarded by jid" do
+      client.mark(:discard, :jid, bad_job["jid"])
+      expect(client.discard_target?(bad_job)).to be_truthy
       expect(client.kill_target?(bad_job)).to be_falsey
-      expect(client.drop_target?(good_job)).to be_falsey
+      expect(client.discard_target?(good_job)).to be_falsey
     end
 
-    it "can mark job to be dropped by bid" do
-      client.mark(:drop, :bid, bad_job["bid"])
-      expect(client.drop_target?(bad_job)).to be_truthy
+    it "can mark job to be discarded by bid" do
+      client.mark(:discard, :bid, bad_job["bid"])
+      expect(client.discard_target?(bad_job)).to be_truthy
       expect(client.kill_target?(bad_job)).to be_falsey
-      expect(client.drop_target?(good_job)).to be_falsey
+      expect(client.discard_target?(good_job)).to be_falsey
     end
 
-    it "can mark job to be dropped by class" do
-      client.mark(:drop, :class, bad_job["class"])
-      expect(client.drop_target?(bad_job)).to be_truthy
+    it "can mark job to be discarded by class" do
+      client.mark(:discard, :class, bad_job["class"])
+      expect(client.discard_target?(bad_job)).to be_truthy
       expect(client.kill_target?(bad_job)).to be_falsey
-      expect(client.drop_target?(good_job)).to be_falsey
+      expect(client.discard_target?(good_job)).to be_falsey
     end
   end
 
@@ -101,9 +101,9 @@ RSpec.describe Sidekiq::Disposal::Client, :with_test_redis do
       client.mark(:kill, :jid, bad_job["jid"])
       client.mark(:kill, :jid, bad_job["jid"]) # To demonstrate idempotence
       client.mark(:kill, :class, bad_job["class"])
-      client.mark(:drop, :class, bad_job2["class"])
+      client.mark(:discard, :class, bad_job2["class"])
       expect(client.markers(:kill).length).to eq(2)
-      expect(client.markers(:drop).length).to eq(1)
+      expect(client.markers(:discard).length).to eq(1)
     end
   end
 end

--- a/spec/sidekiq/disposal/server_middleware_spec.rb
+++ b/spec/sidekiq/disposal/server_middleware_spec.rb
@@ -23,15 +23,15 @@ module Sidekiq
         end.to raise_error(JobKilled)
       end
 
-      it "raises JobDropped error if job has been marked to be dropped" do
-        Client.new.mark(:drop, :class, ServerMiddlewareTestCustomJob.name)
+      it "raises JobDiscarded error if job has been marked to be discarded" do
+        Client.new.mark(:discard, :class, ServerMiddlewareTestCustomJob.name)
         expect do
           middleware.call(ServerMiddlewareTestCustomJob.new, serialized_job, "within_50_years") { :blah }
-        end.to raise_error(JobDropped)
+        end.to raise_error(JobDiscarded)
       end
 
       it "does not raise error if job has been marked but is non-disposable" do
-        Client.new.mark(:drop, :class, ServerMiddlewareTestNonDisposableJob.name)
+        Client.new.mark(:discard, :class, ServerMiddlewareTestNonDisposableJob.name)
         expect do
           middleware.call(ServerMiddlewareTestNonDisposableJob.new, serialized_job, "within_50_years") { :blah }
         end.not_to raise_error


### PR DESCRIPTION
"Discard" is the terminology used by Sidekiq and is even part of the public-facing API (as a possible special value one can return from the `sidekiq_retry_in` block). It doesn't make to diverge from it.